### PR TITLE
Add eslint-config-prettier to integrate ESLint nicely with Prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["next/babel", "next/core-web-vitals"],
+  "extends": ["next/babel", "next/core-web-vitals", "prettier"],
   "rules": {
     "react/no-unescaped-entities": "off",
     "react/jsx-no-target-blank": "off"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "eslint": "7.32.0",
     "eslint-config-next": "13.1.1",
+    "eslint-config-prettier": "^8.8.0",
     "next-sitemap": "^3.1.47",
     "prettier": "2.8.7"
   }


### PR DESCRIPTION
Add eslint-config-prettier to integrate ESLint nicely with Prettier. See https://prettier.io/docs/en/integrating-with-linters.html for reason.